### PR TITLE
Security comment for unsafe

### DIFF
--- a/src/commonMain/kotlin/api.kt
+++ b/src/commonMain/kotlin/api.kt
@@ -103,6 +103,11 @@ fun attributesMapOf(vararg pairs: String?): Map<String, String> {
 
 fun singletonMapOf(key: String, value: String): Map<String, String> = SingletonStringMap(key, value)
 
+/***
+ * unsafe allows writing strings directly into the HTML DOM without any escaping.
+ * In general, setting HTML without escaping is risky because it is easy to expose your users to a cross-site scripting (XSS) attack.
+ * Consider using the builder DSL instead, or ensure that you are escaping the HTML properly.
+ */
 fun HTMLTag.unsafe(block: Unsafe.() -> Unit): Unit = consumer.onTagContentUnsafe(block)
 
 val emptyMap: Map<String, String> = emptyMap()


### PR DESCRIPTION
There is no explanation for why "unsafe" is considered "not safe." A developer who is unaware of the implications might not realize that this is related to XSS and currently has no straightforward way of figuring this out.

This comment provides:
* An explanation of what is happening.
* The use of technical terms (XSS) to allow users to search for more relevant information.
* Two action items.