### PR TITLE
Introduce TagConsumer downcast extension point for DOM interop

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,7 +90,7 @@ kotlin {
         browser {
             testTask {
                 useKarma {
-                    useChromeHeadless()
+                    useFirefox()
                 }
             }
         }
@@ -102,7 +102,13 @@ kotlin {
     }
     wasmJs {
         moduleName = project.name
-        browser()
+        browser {
+            testTask {
+                useKarma {
+                    useFirefox()
+                }
+            }
+        }
 
         mavenPublication {
             groupId = group as String

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,7 +90,7 @@ kotlin {
         browser {
             testTask {
                 useKarma {
-                    useFirefox()
+                    useChromeHeadless()
                 }
             }
         }
@@ -102,13 +102,7 @@ kotlin {
     }
     wasmJs {
         moduleName = project.name
-        browser {
-            testTask {
-                useKarma {
-                    useFirefox()
-                }
-            }
-        }
+        browser()
 
         mavenPublication {
             groupId = group as String

--- a/src/commonMain/kotlin/api.kt
+++ b/src/commonMain/kotlin/api.kt
@@ -1,9 +1,6 @@
 package kotlinx.html
 
 import kotlinx.html.org.w3c.dom.events.Event
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.InvocationKind
-import kotlin.contracts.contract
 
 interface TagConsumer<out R> {
     fun onTagStart(tag: Tag)
@@ -15,11 +12,12 @@ interface TagConsumer<out R> {
     fun onTagContentUnsafe(block: Unsafe.() -> Unit)
     fun onTagComment(content: CharSequence)
     fun finalize(): R
+    @ExperimentalKotlinxHtmlApi
+    val last: Any?
 }
 
-interface InteroperableTagConsumer<I, out R> : TagConsumer<R> {
-    fun onRenderedContent(content: I)
-}
+@RequiresOptIn
+annotation class ExperimentalKotlinxHtmlApi
 
 @HtmlTagMarker
 interface Tag {

--- a/src/commonMain/kotlin/api.kt
+++ b/src/commonMain/kotlin/api.kt
@@ -1,6 +1,9 @@
 package kotlinx.html
 
 import kotlinx.html.org.w3c.dom.events.Event
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 interface TagConsumer<out R> {
     fun onTagStart(tag: Tag)
@@ -12,6 +15,10 @@ interface TagConsumer<out R> {
     fun onTagContentUnsafe(block: Unsafe.() -> Unit)
     fun onTagComment(content: CharSequence)
     fun finalize(): R
+}
+
+interface InteroperableTagConsumer<I, out R> : TagConsumer<R> {
+    fun onRenderedContent(content: I)
 }
 
 @HtmlTagMarker

--- a/src/commonMain/kotlin/api.kt
+++ b/src/commonMain/kotlin/api.kt
@@ -13,7 +13,7 @@ interface TagConsumer<out R> {
     fun onTagComment(content: CharSequence)
     fun finalize(): R
     @ExperimentalKotlinxHtmlApi
-    val last: Any?
+    val head: Any?
 }
 
 @RequiresOptIn

--- a/src/commonMain/kotlin/delayed-consumer.kt
+++ b/src/commonMain/kotlin/delayed-consumer.kt
@@ -49,7 +49,7 @@ class DelayedConsumer<T>(val downstream: TagConsumer<T>) : TagConsumer<T> {
     }
 
     @ExperimentalKotlinxHtmlApi
-    override val last: Any? get() = downstream.last
+    override val head: Any? get() = downstream.head
 
     override fun onTagContentUnsafe(block: Unsafe.() -> Unit) {
         processDelayedTag()

--- a/src/commonMain/kotlin/delayed-consumer.kt
+++ b/src/commonMain/kotlin/delayed-consumer.kt
@@ -48,6 +48,9 @@ class DelayedConsumer<T>(val downstream: TagConsumer<T>) : TagConsumer<T> {
         return downstream.finalize()
     }
 
+    @ExperimentalKotlinxHtmlApi
+    override val last: Any? get() = downstream.last
+
     override fun onTagContentUnsafe(block: Unsafe.() -> Unit) {
         processDelayedTag()
         return downstream.onTagContentUnsafe(block)

--- a/src/commonMain/kotlin/filter-consumer.kt
+++ b/src/commonMain/kotlin/filter-consumer.kt
@@ -83,7 +83,7 @@ private class FilterTagConsumer<T>(val downstream: TagConsumer<T>, val predicate
     override fun finalize(): T = downstream.finalize()
 
     @ExperimentalKotlinxHtmlApi
-    override val last: Any? get() = downstream.last
+    override val head: Any? get() = downstream.head
 }
 
 fun <T> TagConsumer<T>.filter(predicate: PredicateResults.(Tag) -> PredicateResult): TagConsumer<T> =

--- a/src/commonMain/kotlin/filter-consumer.kt
+++ b/src/commonMain/kotlin/filter-consumer.kt
@@ -81,6 +81,9 @@ private class FilterTagConsumer<T>(val downstream: TagConsumer<T>, val predicate
     }
 
     override fun finalize(): T = downstream.finalize()
+
+    @ExperimentalKotlinxHtmlApi
+    override val last: Any? get() = downstream.last
 }
 
 fun <T> TagConsumer<T>.filter(predicate: PredicateResults.(Tag) -> PredicateResult): TagConsumer<T> =

--- a/src/commonMain/kotlin/finalize-consumer.kt
+++ b/src/commonMain/kotlin/finalize-consumer.kt
@@ -28,7 +28,7 @@ class FinalizeConsumer<F, T>(val downstream: TagConsumer<F>, val block: (F, Bool
     override fun finalize() = block(downstream.finalize(), level > 0)
 
     @ExperimentalKotlinxHtmlApi
-    override val last: Any? get() = downstream.last
+    override val head: Any? get() = downstream.head
 }
 
 public fun <T> TagConsumer<T>.onFinalize(block: (from: T, partial: Boolean) -> Unit): TagConsumer<T> =

--- a/src/commonMain/kotlin/finalize-consumer.kt
+++ b/src/commonMain/kotlin/finalize-consumer.kt
@@ -26,6 +26,9 @@ class FinalizeConsumer<F, T>(val downstream: TagConsumer<F>, val block: (F, Bool
     override fun onTagComment(content: CharSequence) = downstream.onTagComment(content)
 
     override fun finalize() = block(downstream.finalize(), level > 0)
+
+    @ExperimentalKotlinxHtmlApi
+    override val last: Any? get() = downstream.last
 }
 
 public fun <T> TagConsumer<T>.onFinalize(block: (from: T, partial: Boolean) -> Unit): TagConsumer<T> =

--- a/src/commonMain/kotlin/measure-consumer.kt
+++ b/src/commonMain/kotlin/measure-consumer.kt
@@ -41,6 +41,9 @@ private class TimeMeasureConsumer<R>(val downstream: TagConsumer<R>, val start: 
     }
 
     override fun finalize(): TimedValue<R> = TimedValue(downstream.finalize(), start.elapsedNow())
+
+    @ExperimentalKotlinxHtmlApi
+    override val last: Any? get() = downstream.last
 }
 
 fun <R> TagConsumer<R>.measureTime(timeSource: TimeSource = TimeSource.Monotonic): TagConsumer<TimedValue<R>> = TimeMeasureConsumer(this, timeSource.markNow())

--- a/src/commonMain/kotlin/measure-consumer.kt
+++ b/src/commonMain/kotlin/measure-consumer.kt
@@ -43,7 +43,7 @@ private class TimeMeasureConsumer<R>(val downstream: TagConsumer<R>, val start: 
     override fun finalize(): TimedValue<R> = TimedValue(downstream.finalize(), start.elapsedNow())
 
     @ExperimentalKotlinxHtmlApi
-    override val last: Any? get() = downstream.last
+    override val head: Any? get() = downstream.head
 }
 
 fun <R> TagConsumer<R>.measureTime(timeSource: TimeSource = TimeSource.Monotonic): TagConsumer<TimedValue<R>> = TimeMeasureConsumer(this, timeSource.markNow())

--- a/src/commonMain/kotlin/stream.kt
+++ b/src/commonMain/kotlin/stream.kt
@@ -89,7 +89,6 @@ class HTMLStreamBuilder<out O : Appendable>(
     @ExperimentalKotlinxHtmlApi
     override val last: Any? get() = out
 
-
     override fun onTagContentUnsafe(block: Unsafe.() -> Unit) {
         UnsafeImpl.block()
     }

--- a/src/commonMain/kotlin/stream.kt
+++ b/src/commonMain/kotlin/stream.kt
@@ -86,6 +86,10 @@ class HTMLStreamBuilder<out O : Appendable>(
 
     override fun finalize(): O = out
 
+    @ExperimentalKotlinxHtmlApi
+    override val last: Any? get() = out
+
+
     override fun onTagContentUnsafe(block: Unsafe.() -> Unit) {
         UnsafeImpl.block()
     }

--- a/src/commonMain/kotlin/stream.kt
+++ b/src/commonMain/kotlin/stream.kt
@@ -87,7 +87,7 @@ class HTMLStreamBuilder<out O : Appendable>(
     override fun finalize(): O = out
 
     @ExperimentalKotlinxHtmlApi
-    override val last: Any? get() = out
+    override val head: O get() = out
 
     override fun onTagContentUnsafe(block: Unsafe.() -> Unit) {
         UnsafeImpl.block()

--- a/src/jsMain/kotlin/dom-js.kt
+++ b/src/jsMain/kotlin/dom-js.kt
@@ -2,12 +2,10 @@ package kotlinx.html.dom
 
 import kotlinx.html.DefaultUnsafe
 import kotlinx.html.Entities
-import kotlinx.html.FlowContent
-import kotlinx.html.InteroperableTagConsumer
+import kotlinx.html.ExperimentalKotlinxHtmlApi
 import kotlinx.html.Tag
 import kotlinx.html.TagConsumer
 import kotlinx.html.Unsafe
-import kotlinx.html.consumers.FinalizeConsumer
 import kotlinx.html.consumers.onFinalize
 import kotlinx.html.org.w3c.dom.events.Event
 import org.w3c.dom.Document
@@ -24,7 +22,7 @@ private inline fun HTMLElement.setEvent(name: String, noinline callback : (Event
     asDynamic()[name] = callback
 }
 
-class JSDOMBuilder<out R : HTMLElement>(val document : Document) : InteroperableTagConsumer<Node, R> {
+class JSDOMBuilder<out R : HTMLElement>(val document : Document) : TagConsumer<R> {
     private val path = arrayListOf<HTMLElement>()
     private var lastLeaved : HTMLElement? = null
 
@@ -116,24 +114,11 @@ class JSDOMBuilder<out R : HTMLElement>(val document : Document) : Interoperable
 
     override fun finalize(): R = lastLeaved?.asR() ?: throw IllegalStateException("We can't finalize as there was no tags")
 
+    @ExperimentalKotlinxHtmlApi
+    override val last: Any? get() = path.lastOrNull()
+
     @Suppress("UnsafeCastFromDynamic")
     private fun HTMLElement.asR(): R = this.asDynamic()
-
-    override fun onRenderedContent(content: Node) {
-        path.last().appendChild(content)
-    }
-}
-
-@OptIn(ExperimentalContracts::class)
-inline fun FlowContent.dom(crossinline block: () -> Node) {
-    contract { callsInPlace(block, InvocationKind.AT_MOST_ONCE) }
-    val consumer = when (val topConsumer = consumer) {
-        is FinalizeConsumer<*,*> -> topConsumer.downstream
-        else -> null
-    }
-    if (consumer is JSDOMBuilder) {
-        consumer.onRenderedContent(block())
-    }
 }
 
  fun Document.createTree() : TagConsumer<HTMLElement> = JSDOMBuilder(this)

--- a/src/jsMain/kotlin/dom-js.kt
+++ b/src/jsMain/kotlin/dom-js.kt
@@ -115,7 +115,7 @@ class JSDOMBuilder<out R : HTMLElement>(val document : Document) : TagConsumer<R
     override fun finalize(): R = lastLeaved?.asR() ?: throw IllegalStateException("We can't finalize as there was no tags")
 
     @ExperimentalKotlinxHtmlApi
-    override val last: Any? get() = path.lastOrNull()
+    override val head: HTMLElement get() = path.last()
 
     @Suppress("UnsafeCastFromDynamic")
     private fun HTMLElement.asR(): R = this.asDynamic()

--- a/src/jsMain/kotlin/dom-js.kt
+++ b/src/jsMain/kotlin/dom-js.kt
@@ -2,9 +2,12 @@ package kotlinx.html.dom
 
 import kotlinx.html.DefaultUnsafe
 import kotlinx.html.Entities
+import kotlinx.html.FlowContent
+import kotlinx.html.InteroperableTagConsumer
 import kotlinx.html.Tag
 import kotlinx.html.TagConsumer
 import kotlinx.html.Unsafe
+import kotlinx.html.consumers.FinalizeConsumer
 import kotlinx.html.consumers.onFinalize
 import kotlinx.html.org.w3c.dom.events.Event
 import org.w3c.dom.Document
@@ -21,7 +24,7 @@ private inline fun HTMLElement.setEvent(name: String, noinline callback : (Event
     asDynamic()[name] = callback
 }
 
-class JSDOMBuilder<out R : HTMLElement>(val document : Document) : TagConsumer<R> {
+class JSDOMBuilder<out R : HTMLElement>(val document : Document) : InteroperableTagConsumer<Node, R> {
     private val path = arrayListOf<HTMLElement>()
     private var lastLeaved : HTMLElement? = null
 
@@ -116,8 +119,22 @@ class JSDOMBuilder<out R : HTMLElement>(val document : Document) : TagConsumer<R
     @Suppress("UnsafeCastFromDynamic")
     private fun HTMLElement.asR(): R = this.asDynamic()
 
+    override fun onRenderedContent(content: Node) {
+        path.last().appendChild(content)
+    }
 }
 
+@OptIn(ExperimentalContracts::class)
+inline fun FlowContent.dom(crossinline block: () -> Node) {
+    contract { callsInPlace(block, InvocationKind.AT_MOST_ONCE) }
+    val consumer = when (val topConsumer = consumer) {
+        is FinalizeConsumer<*,*> -> topConsumer.downstream
+        else -> null
+    }
+    if (consumer is JSDOMBuilder) {
+        consumer.onRenderedContent(block())
+    }
+}
 
  fun Document.createTree() : TagConsumer<HTMLElement> = JSDOMBuilder(this)
  val Document.create : TagConsumer<HTMLElement>

--- a/src/jsTest/kotlin/interoperable.kt
+++ b/src/jsTest/kotlin/interoperable.kt
@@ -1,0 +1,22 @@
+import kotlinx.browser.document
+import kotlinx.html.js.div
+import kotlinx.html.dom.append
+import kotlinx.html.dom.dom
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class InteroperableImplTest {
+    @Test fun testInteroperableDOM() {
+        val wrapper = wrapper()
+
+        wrapper.append.div {
+            dom {
+                document.createElement("svg")
+            }
+        }
+
+        assertEquals(expected = "<div><svg></svg></div>", actual = wrapper.innerHTML)
+    }
+
+    private fun wrapper() = document.body!!.append.div {}
+}

--- a/src/jsTest/kotlin/interoperable.kt
+++ b/src/jsTest/kotlin/interoperable.kt
@@ -26,7 +26,7 @@ class InteroperableImplTest {
 
     // Stand in for how a library might want to interop with kotlinx-html
     private fun Tag.interop(block: () -> Node) {
-        val last = consumer.last as HTMLElement
+        val last = consumer.head as HTMLElement
         last.appendChild(block())
     }
 }

--- a/src/jsTest/kotlin/interoperable.kt
+++ b/src/jsTest/kotlin/interoperable.kt
@@ -1,16 +1,20 @@
 import kotlinx.browser.document
+import kotlinx.html.ExperimentalKotlinxHtmlApi
+import kotlinx.html.Tag
 import kotlinx.html.js.div
 import kotlinx.html.dom.append
-import kotlinx.html.dom.dom
+import org.w3c.dom.HTMLElement
+import org.w3c.dom.Node
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@OptIn(ExperimentalKotlinxHtmlApi::class)
 class InteroperableImplTest {
     @Test fun testInteroperableDOM() {
         val wrapper = wrapper()
 
         wrapper.append.div {
-            dom {
+            interop {
                 document.createElement("svg")
             }
         }
@@ -19,4 +23,10 @@ class InteroperableImplTest {
     }
 
     private fun wrapper() = document.body!!.append.div {}
+
+    // Stand in for how a library might want to interop with kotlinx-html
+    private fun Tag.interop(block: () -> Node) {
+        val last = consumer.last as HTMLElement
+        last.appendChild(block())
+    }
 }

--- a/src/jvmMain/kotlin/dom-jvm.kt
+++ b/src/jvmMain/kotlin/dom-jvm.kt
@@ -102,7 +102,7 @@ class HTMLDOMBuilder(val document : Document) : TagConsumer<Element> {
     override fun finalize() = lastLeaved ?: throw IllegalStateException("No tags were emitted")
 
     @ExperimentalKotlinxHtmlApi
-    override val last: Any? get() = path.lastOrNull()
+    override val head: Element get() = path.last()
 
     override fun onTagContentUnsafe(block: Unsafe.() -> Unit) {
         UnsafeImpl.block()

--- a/src/jvmMain/kotlin/dom-jvm.kt
+++ b/src/jvmMain/kotlin/dom-jvm.kt
@@ -1,6 +1,7 @@
 package kotlinx.html.dom
 
 import kotlinx.html.Entities
+import kotlinx.html.ExperimentalKotlinxHtmlApi
 import kotlinx.html.Tag
 import kotlinx.html.TagConsumer
 import kotlinx.html.Unsafe
@@ -99,6 +100,9 @@ class HTMLDOMBuilder(val document : Document) : TagConsumer<Element> {
     }
 
     override fun finalize() = lastLeaved ?: throw IllegalStateException("No tags were emitted")
+
+    @ExperimentalKotlinxHtmlApi
+    override val last: Any? get() = path.lastOrNull()
 
     override fun onTagContentUnsafe(block: Unsafe.() -> Unit) {
         UnsafeImpl.block()

--- a/src/jvmTest/kotlin/interoperable.kt
+++ b/src/jvmTest/kotlin/interoperable.kt
@@ -1,0 +1,30 @@
+import kotlinx.html.ExperimentalKotlinxHtmlApi
+import kotlinx.html.Tag
+import kotlinx.html.div
+import kotlinx.html.dom.createHTMLDocument
+import kotlinx.html.dom.serialize
+import org.w3c.dom.Document
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalKotlinxHtmlApi::class)
+class InteroperableImplTest {
+    @Test fun testInteroperableDOM() {
+        DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument()
+        val tree = createHTMLDocument().div {
+            interop {
+                it.createElement("svg")
+            }
+        }
+        assertEquals(expected = "<!DOCTYPE html>\n<div><svg></svg></div>", actual = tree.serialize(prettyPrint = false))
+    }
+
+    // Stand in for how a library might want to interop with kotlinx-html
+    private fun Tag.interop(block: (Document) -> Node) {
+        val last = consumer.last as Element
+        last.appendChild(block(last.ownerDocument))
+    }
+}

--- a/src/jvmTest/kotlin/interoperable.kt
+++ b/src/jvmTest/kotlin/interoperable.kt
@@ -24,7 +24,7 @@ class InteroperableImplTest {
 
     // Stand in for how a library might want to interop with kotlinx-html
     private fun Tag.interop(block: (Document) -> Node) {
-        val last = consumer.last as Element
+        val last = consumer.head as Element
         last.appendChild(block(last.ownerDocument))
     }
 }

--- a/src/wasmJsMain/kotlin/dom-js.kt
+++ b/src/wasmJsMain/kotlin/dom-js.kt
@@ -2,9 +2,12 @@ package kotlinx.html.dom
 
 import kotlinx.html.DefaultUnsafe
 import kotlinx.html.Entities
+import kotlinx.html.FlowContent
+import kotlinx.html.InteroperableTagConsumer
 import kotlinx.html.Tag
 import kotlinx.html.TagConsumer
 import kotlinx.html.Unsafe
+import kotlinx.html.consumers.FinalizeConsumer
 import kotlinx.html.consumers.onFinalize
 import kotlinx.html.org.w3c.dom.events.Event
 import org.w3c.dom.Document
@@ -21,7 +24,7 @@ private inline fun Element.setEvent(name: String, noinline callback: (Event) -> 
     addEventListener(eventName, callback)
 }
 
-class JSDOMBuilder<out R : HTMLElement>(val document: Document) : TagConsumer<R> {
+class JSDOMBuilder<out R : HTMLElement>(val document: Document) : InteroperableTagConsumer<Node, R> {
     private val path = arrayListOf<Element>()
     private var lastLeaved: Element? = null
 
@@ -117,10 +120,26 @@ class JSDOMBuilder<out R : HTMLElement>(val document: Document) : TagConsumer<R>
     override fun finalize(): R =
         lastLeaved?.asR() ?: throw IllegalStateException("We can't finalize as there was no tags")
 
+    override fun onRenderedContent(content: Node) {
+        path.last().appendChild(content)
+    }
+
     private inline fun Element.asR(): R {
         return jsCast(this)
     }
 
+}
+
+@OptIn(ExperimentalContracts::class)
+inline fun FlowContent.dom(crossinline block: () -> Node) {
+    contract { callsInPlace(block, InvocationKind.AT_MOST_ONCE) }
+    val consumer = when (val topConsumer = consumer) {
+        is FinalizeConsumer<*,*> -> topConsumer.downstream
+        else -> null
+    }
+    if (consumer is JSDOMBuilder) {
+        consumer.onRenderedContent(block())
+    }
 }
 
 fun <T : JsAny> jsCast(any: JsAny): T = js("(any)")

--- a/src/wasmJsMain/kotlin/dom-js.kt
+++ b/src/wasmJsMain/kotlin/dom-js.kt
@@ -2,12 +2,10 @@ package kotlinx.html.dom
 
 import kotlinx.html.DefaultUnsafe
 import kotlinx.html.Entities
-import kotlinx.html.FlowContent
-import kotlinx.html.InteroperableTagConsumer
+import kotlinx.html.ExperimentalKotlinxHtmlApi
 import kotlinx.html.Tag
 import kotlinx.html.TagConsumer
 import kotlinx.html.Unsafe
-import kotlinx.html.consumers.FinalizeConsumer
 import kotlinx.html.consumers.onFinalize
 import kotlinx.html.org.w3c.dom.events.Event
 import org.w3c.dom.Document
@@ -24,7 +22,7 @@ private inline fun Element.setEvent(name: String, noinline callback: (Event) -> 
     addEventListener(eventName, callback)
 }
 
-class JSDOMBuilder<out R : HTMLElement>(val document: Document) : InteroperableTagConsumer<Node, R> {
+class JSDOMBuilder<out R : HTMLElement>(val document: Document) : TagConsumer<R> {
     private val path = arrayListOf<Element>()
     private var lastLeaved: Element? = null
 
@@ -120,25 +118,11 @@ class JSDOMBuilder<out R : HTMLElement>(val document: Document) : InteroperableT
     override fun finalize(): R =
         lastLeaved?.asR() ?: throw IllegalStateException("We can't finalize as there was no tags")
 
-    override fun onRenderedContent(content: Node) {
-        path.last().appendChild(content)
-    }
+    @ExperimentalKotlinxHtmlApi
+    override val last: Any? get() = path.lastOrNull()
 
     private inline fun Element.asR(): R {
         return jsCast(this)
-    }
-
-}
-
-@OptIn(ExperimentalContracts::class)
-inline fun FlowContent.dom(crossinline block: () -> Node) {
-    contract { callsInPlace(block, InvocationKind.AT_MOST_ONCE) }
-    val consumer = when (val topConsumer = consumer) {
-        is FinalizeConsumer<*,*> -> topConsumer.downstream
-        else -> null
-    }
-    if (consumer is JSDOMBuilder) {
-        consumer.onRenderedContent(block())
     }
 }
 

--- a/src/wasmJsMain/kotlin/dom-js.kt
+++ b/src/wasmJsMain/kotlin/dom-js.kt
@@ -119,7 +119,7 @@ class JSDOMBuilder<out R : HTMLElement>(val document: Document) : TagConsumer<R>
         lastLeaved?.asR() ?: throw IllegalStateException("We can't finalize as there was no tags")
 
     @ExperimentalKotlinxHtmlApi
-    override val last: Any? get() = path.lastOrNull()
+    override val head: Element get() = path.last()
 
     private inline fun Element.asR(): R {
         return jsCast(this)

--- a/src/wasmJsTest/kotlin/interoperable.kt
+++ b/src/wasmJsTest/kotlin/interoperable.kt
@@ -1,0 +1,22 @@
+import kotlinx.browser.document
+import kotlinx.html.js.div
+import kotlinx.html.dom.append
+import kotlinx.html.dom.dom
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class InteroperableImplTest {
+    @Test fun testInteroperableDOM() {
+        val wrapper = wrapper()
+
+        wrapper.append.div {
+            dom {
+                document.createElement("svg")
+            }
+        }
+
+        assertEquals(expected = "<div><svg></svg></div>", actual = wrapper.innerHTML)
+    }
+
+    private fun wrapper() = document.body!!.append.div {}
+}

--- a/src/wasmJsTest/kotlin/interoperable.kt
+++ b/src/wasmJsTest/kotlin/interoperable.kt
@@ -26,7 +26,7 @@ class InteroperableImplTest {
 
     // Stand in for how a library might want to interop with kotlinx-html
     private fun Tag.interop(block: () -> Node) {
-        val last = consumer.last as HTMLElement
+        val last = consumer.head as HTMLElement
         last.appendChild(block())
     }
 }

--- a/src/wasmJsTest/kotlin/interoperable.kt
+++ b/src/wasmJsTest/kotlin/interoperable.kt
@@ -1,16 +1,20 @@
 import kotlinx.browser.document
+import kotlinx.html.ExperimentalKotlinxHtmlApi
+import kotlinx.html.Tag
 import kotlinx.html.js.div
 import kotlinx.html.dom.append
-import kotlinx.html.dom.dom
+import org.w3c.dom.HTMLElement
+import org.w3c.dom.Node
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@OptIn(ExperimentalKotlinxHtmlApi::class)
 class InteroperableImplTest {
     @Test fun testInteroperableDOM() {
         val wrapper = wrapper()
 
         wrapper.append.div {
-            dom {
+            interop {
                 document.createElement("svg")
             }
         }
@@ -19,4 +23,10 @@ class InteroperableImplTest {
     }
 
     private fun wrapper() = document.body!!.append.div {}
+
+    // Stand in for how a library might want to interop with kotlinx-html
+    private fun Tag.interop(block: () -> Node) {
+        val last = consumer.last as HTMLElement
+        last.appendChild(block())
+    }
 }


### PR DESCRIPTION
I am working on an [implementation of the SVG 1.1 protocol](https://github.com/yoxjames/svg4k). One thing I would really like to be able to do is seamless inter-operation with `kotlinx-html`. However I ran into an issue. For most targets, where the HTML being generated is really just text, this can be accomplished by simply using the unsafe raw text API:

```kotlin
val html = buildString {
            appendHTML(prettyPrint = true).html {
                body {
                    div {
                        unsafe {
                            raw(svgString { // My DSL Begins
                                svg {
                                  // Can use all the SVG elements you want in here
                                }
                            })
                        }
                    }
                }
            }
        }
```

I could easily refactor this into an extension function that simply taps into the raw call. In fact, there are quite a few examples of libraries that have done this. However on targets like JS or WasmJS, kotlinx-html actually generates DOM elements. If I attempt to tap into the raw(...) calls I'll just be adding text to DOM elements and not adding DOM elements!

I want the ability for one DSL to seamlessly interoperate with `kotlinx-html` on those targets! Obviously this was created due to a need for a library I am developing, but this should be generic enough to be used _any library_ that would like to interop this way.

Right now, if I want to create an extension function it look something like this:
```kotlin
fun <T> TagConsumer<HTMLElement>.svg4k(
    block: context(dev.jamesyox.svg4k.TagConsumer<SVGElement>, RootContainer) () -> T
): T {
    val tagConsumer = JsDomTagConsumer(document)
    val output = block(tagConsumer, RootContainer)
    val svgDom = tagConsumer.output()
    val hackDiv = div { }
    val currentNode = hackDiv.parentNode
    currentNode?.removeChild(hackDiv)

    currentNode?.let {
        svgDom.forEach { child -> it.appendChild(child) }
    }
    return output
}
```
Essentially I create a `div` so that I can get what that method returns as I have no way to grab the HTML element inside of the DSL. I brought this up on slack as well:
https://kotlinlang.slack.com/archives/CKWA2MV8U/p1771194798125389

This solution "works" but I'll be honest that it has some aspects I don't love, I'll get into those with comments. 